### PR TITLE
fix mirai-console moves file error

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,14 +2,14 @@ plugins {
     val kotlinVersion = "1.4.30"
     kotlin("jvm") version kotlinVersion
     kotlin("plugin.serialization") version kotlinVersion
-    id("net.mamoe.mirai-console") version "2.6.7"
+    id("net.mamoe.mirai-console") version "2.9.2"
 }
 
 group = "com.billyang"
 version = "1.1.1"
 
 repositories {
-    maven{ url =uri("https://maven.aliyun.com/nexus/content/groups/public/")}
+    maven("https://maven.aliyun.com/repository/public")
     jcenter()
     mavenCentral()
     mavenLocal()

--- a/src/main/java/com/billyang/entrylib/Database/Database.java
+++ b/src/main/java/com/billyang/entrylib/Database/Database.java
@@ -1,5 +1,6 @@
 package com.billyang.entrylib.Database;
 
+import com.billyang.entrylib.EntryLib;
 import com.billyang.entrylib.Subgroup.Subgroup;
 
 import java.io.File;
@@ -17,15 +18,14 @@ import java.util.Random;
  */
 public class Database {
 
-    public final static String DATABASES_PATH = "data/com.billyang.entrylib/databases/";
-
     /**
      * 初始化
      * @return 成功状态
      */
     public boolean init() {
-        File file = new File(DATABASES_PATH);
+        File file = new File(EntryLib.DATABASES_FOLDER);
         if(!file.exists()) {
+            EntryLib.INSTANCE.getLogger().info("创建数据库目录");
             file.mkdirs();
         }
 
@@ -119,7 +119,7 @@ public class Database {
      * @return 连接情况
      */
     public boolean connect(long groupId) {
-        return connect("jdbc:sqlite:" + DATABASES_PATH + groupId + ".db");
+        return connect("jdbc:sqlite:" + EntryLib.DATABASES_FOLDER + groupId + ".db");
     }
 
     /**
@@ -129,7 +129,7 @@ public class Database {
      * @see Subgroup
      */
     public boolean connect(Subgroup subgroup) {
-        return connect("jdbc:sqlite:" + DATABASES_PATH + subgroup.getName() + ".db");
+        return connect("jdbc:sqlite:" + EntryLib.DATABASES_FOLDER + subgroup.getName() + ".db");
     }
 
     /**

--- a/src/main/java/com/billyang/entrylib/Database/Database.java
+++ b/src/main/java/com/billyang/entrylib/Database/Database.java
@@ -17,12 +17,14 @@ import java.util.Random;
  */
 public class Database {
 
+    public final static String DATABASES_PATH = "data/com.billyang.entrylib/databases/";
+
     /**
      * 初始化
      * @return 成功状态
      */
     public boolean init() {
-        File file = new File("data/EntryLib/databases/");
+        File file = new File(DATABASES_PATH);
         if(!file.exists()) {
             file.mkdirs();
         }
@@ -117,7 +119,7 @@ public class Database {
      * @return 连接情况
      */
     public boolean connect(long groupId) {
-        return connect("jdbc:sqlite:data/EntryLib/databases/" + groupId + ".db");
+        return connect("jdbc:sqlite:" + DATABASES_PATH + groupId + ".db");
     }
 
     /**
@@ -127,7 +129,7 @@ public class Database {
      * @see Subgroup
      */
     public boolean connect(Subgroup subgroup) {
-        return connect("jdbc:sqlite:data/EntryLib/databases/" + subgroup.getName() + ".db");
+        return connect("jdbc:sqlite:" + DATABASES_PATH + subgroup.getName() + ".db");
     }
 
     /**

--- a/src/main/java/com/billyang/entrylib/Database/DatabaseAutoArranger.java
+++ b/src/main/java/com/billyang/entrylib/Database/DatabaseAutoArranger.java
@@ -35,7 +35,7 @@ class ImageCleaner implements Runnable {
      * 线程运行方法
      */
     public void run() {
-        File imageFolder = new File("data/EntryLib/images/");
+        File imageFolder = new File(Database.DATABASES_PATH);
         if(imageFolder.exists()) {
             List<File> tempList = Arrays.asList(imageFolder.listFiles());
             List<File> imageFiles = new ArrayList(tempList);
@@ -113,7 +113,7 @@ public class DatabaseAutoArranger extends TimerTask {
     boolean connect(String database) {
         try {
             Class.forName("org.sqlite.JDBC");
-            c = DriverManager.getConnection("jdbc:sqlite:data/EntryLib/databases/" + database);
+            c = DriverManager.getConnection("jdbc:sqlite:" + Database.DATABASES_PATH + database);
 
             stmt = c.createStatement();
             if(!exists(stmt, "__MAIN_TABLE")) return false;
@@ -315,7 +315,7 @@ public class DatabaseAutoArranger extends TimerTask {
             end = mt.end();
 
             String imageId = ImageParser.MiraiCode2Id(text.substring(start, end));
-            File file = new File("data/EntryLib/images/", imageId);
+            File file = new File("data/com.billyang.entrylib/images/", imageId);
 
             if(file.exists())list.add(file);
         }
@@ -365,7 +365,7 @@ public class DatabaseAutoArranger extends TimerTask {
      */
     @Override
     public void run() {
-        File file = new File("data/EntryLib/databases/");
+        File file = new File(Database.DATABASES_PATH);
         if(!file.exists()) return;
 
         File[] files = file.listFiles();

--- a/src/main/java/com/billyang/entrylib/Database/DatabaseAutoArranger.java
+++ b/src/main/java/com/billyang/entrylib/Database/DatabaseAutoArranger.java
@@ -16,6 +16,7 @@ import java.util.regex.Pattern;
  * 清理没有用过的图片
  */
 class ImageCleaner implements Runnable {
+
     private Thread t;
 
     EntryLib entrylib;
@@ -35,7 +36,7 @@ class ImageCleaner implements Runnable {
      * 线程运行方法
      */
     public void run() {
-        File imageFolder = new File(Database.DATABASES_PATH);
+        File imageFolder = new File(EntryLib.IMAGES_FOLDER);
         if(imageFolder.exists()) {
             List<File> tempList = Arrays.asList(imageFolder.listFiles());
             List<File> imageFiles = new ArrayList(tempList);
@@ -113,7 +114,7 @@ public class DatabaseAutoArranger extends TimerTask {
     boolean connect(String database) {
         try {
             Class.forName("org.sqlite.JDBC");
-            c = DriverManager.getConnection("jdbc:sqlite:" + Database.DATABASES_PATH + database);
+            c = DriverManager.getConnection("jdbc:sqlite:" + EntryLib.DATABASES_FOLDER + database);
 
             stmt = c.createStatement();
             if(!exists(stmt, "__MAIN_TABLE")) return false;
@@ -315,7 +316,7 @@ public class DatabaseAutoArranger extends TimerTask {
             end = mt.end();
 
             String imageId = ImageParser.MiraiCode2Id(text.substring(start, end));
-            File file = new File("data/com.billyang.entrylib/images/", imageId);
+            File file = new File(EntryLib.IMAGES_FOLDER, imageId);
 
             if(file.exists())list.add(file);
         }
@@ -365,7 +366,7 @@ public class DatabaseAutoArranger extends TimerTask {
      */
     @Override
     public void run() {
-        File file = new File(Database.DATABASES_PATH);
+        File file = new File(EntryLib.DATABASES_FOLDER);
         if(!file.exists()) return;
 
         File[] files = file.listFiles();

--- a/src/main/java/com/billyang/entrylib/Database/DatabaseUpdater.java
+++ b/src/main/java/com/billyang/entrylib/Database/DatabaseUpdater.java
@@ -106,7 +106,7 @@ public class DatabaseUpdater {
      * 数据库升级任务
      */
     public void update() {
-        File file = new File(Database.DATABASES_PATH);
+        File file = new File(EntryLib.DATABASES_FOLDER);
         if(!file.exists()) return;
 
         File[] files = file.listFiles();
@@ -121,7 +121,7 @@ public class DatabaseUpdater {
             String fileName = dbFile.getName();
             if(!fileName.endsWith(".db")) continue; //保证文件是数据库文件
 
-            if(!database.connect("jdbc:sqlite:" + Database.DATABASES_PATH + fileName)) {
+            if(!database.connect("jdbc:sqlite:" + EntryLib.DATABASES_FOLDER + fileName)) {
                 entrylib.getLogger().warning("无法升级数据库" + fileName + "：数据库连接失败！");
                 database.close();
                 continue;

--- a/src/main/java/com/billyang/entrylib/Database/DatabaseUpdater.java
+++ b/src/main/java/com/billyang/entrylib/Database/DatabaseUpdater.java
@@ -106,7 +106,7 @@ public class DatabaseUpdater {
      * 数据库升级任务
      */
     public void update() {
-        File file = new File("data/EntryLib/databases/");
+        File file = new File(Database.DATABASES_PATH);
         if(!file.exists()) return;
 
         File[] files = file.listFiles();
@@ -121,7 +121,7 @@ public class DatabaseUpdater {
             String fileName = dbFile.getName();
             if(!fileName.endsWith(".db")) continue; //保证文件是数据库文件
 
-            if(!database.connect("jdbc:sqlite:data/EntryLib/databases/" + fileName)) {
+            if(!database.connect("jdbc:sqlite:" + Database.DATABASES_PATH + fileName)) {
                 entrylib.getLogger().warning("无法升级数据库" + fileName + "：数据库连接失败！");
                 database.close();
                 continue;

--- a/src/main/java/com/billyang/entrylib/EntryLib.java
+++ b/src/main/java/com/billyang/entrylib/EntryLib.java
@@ -36,6 +36,8 @@ import java.util.regex.Pattern;
  */
 public final class EntryLib extends JavaPlugin {
     public static final EntryLib INSTANCE = new EntryLib();
+    public static final String IMAGES_FOLDER = INSTANCE.getDataFolder().getAbsolutePath() + "/images/";
+    public static final String DATABASES_FOLDER = INSTANCE.getDataFolder().getAbsolutePath() + "/databases/";
     private EntryLib() {
         super(new JvmPluginDescriptionBuilder("EntryLib", "1.1.1")
                 .id("com.billyang.entrylib")

--- a/src/main/java/com/billyang/entrylib/EntryLib.java
+++ b/src/main/java/com/billyang/entrylib/EntryLib.java
@@ -469,6 +469,8 @@ public final class EntryLib extends JavaPlugin {
     @Override
     public void onEnable() {
 
+        pl.init();
+
         String DataFolderPath = getDataFolder().getAbsolutePath();
         getLogger().info("配置文件目录：" + DataFolderPath);
 

--- a/src/main/java/com/billyang/entrylib/EntryPackage/PackageLoader.java
+++ b/src/main/java/com/billyang/entrylib/EntryPackage/PackageLoader.java
@@ -31,7 +31,8 @@ public class PackageLoader {
      * 自动初始化
      */
     public PackageLoader() {
-        init();
+        // 自动初始化会导致数据文件被占用，mirai-console 无法自动迁移
+//        init();
     }
 
     /**

--- a/src/main/java/com/billyang/entrylib/ui/FloatingWindow.java
+++ b/src/main/java/com/billyang/entrylib/ui/FloatingWindow.java
@@ -345,7 +345,7 @@ public class FloatingWindow extends JFrame {
                 groupId = 0;
             }
 
-            File database = new File(Database.DATABASES_PATH, groupId + ".db");
+            File database = new File(EntryLib.DATABASES_FOLDER, groupId + ".db");
             if(!database.exists()) {
                 JOptionPane.showMessageDialog(
                         panel, "目标群数据库不存在", "错误", JOptionPane.ERROR_MESSAGE

--- a/src/main/java/com/billyang/entrylib/ui/FloatingWindow.java
+++ b/src/main/java/com/billyang/entrylib/ui/FloatingWindow.java
@@ -1,6 +1,7 @@
 package com.billyang.entrylib.ui;
 
 import com.billyang.entrylib.Config.UserIO;
+import com.billyang.entrylib.Database.Database;
 import com.billyang.entrylib.EntryLib;
 import com.billyang.entrylib.Matcher.MatchLoader;
 
@@ -344,7 +345,7 @@ public class FloatingWindow extends JFrame {
                 groupId = 0;
             }
 
-            File database = new File("data/EntryLib/databases/", groupId + ".db");
+            File database = new File(Database.DATABASES_PATH, groupId + ".db");
             if(!database.exists()) {
                 JOptionPane.showMessageDialog(
                         panel, "目标群数据库不存在", "错误", JOptionPane.ERROR_MESSAGE


### PR DESCRIPTION
for #17 

更改内容：
- 升级 mirai-console 插件至 2.9.2
- 定义 EntryLib 类静态变量 DATABASES_FOLDER 与 IMAGES_FOLDER
- PackageLoader 不再自动初始化，以解决插件数据文件夹被占用导致 mirai-console 迁移插件数据失败 

PS：注意备份词条数据库